### PR TITLE
Fix code scanning alert no. 15: Information exposure through an exception

### DIFF
--- a/app/django/apiV1/serializers/contract.py
+++ b/app/django/apiV1/serializers/contract.py
@@ -458,7 +458,12 @@ class ContractSetSerializer(serializers.ModelSerializer):
             except ContractFile.DoesNotExist:
                 raise serializers.ValidationError(f"File with ID {edit_file} does not exist.")
             except Exception as e:
-                raise serializers.ValidationError(f'Error while replacing file: {str(e)}')
+                # Log the detailed error message
+                import logging
+                logger = logging.getLogger(__name__)
+                logger.error(f'Error while replacing file: {str(e)}')
+                # Raise a generic error message
+                raise serializers.ValidationError('An error occurred while replacing the file.')
 
         del_file = self.initial_data.get('delFile', None)
         if del_file:


### PR DESCRIPTION
Fixes [https://github.com/nc2U/ibs/security/code-scanning/15](https://github.com/nc2U/ibs/security/code-scanning/15)

To fix the problem, we should replace the detailed exception message with a generic error message that does not reveal any sensitive information. The detailed error message should be logged on the server for debugging purposes. This approach ensures that internal details are not exposed to the end user while still allowing developers to diagnose issues.

1. Modify the exception handling on line 461 to log the detailed error message.
2. Return a generic error message in the `ValidationError`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
