### PR TITLE
Fix code scanning alert no. 16: Information exposure through an exception

### DIFF
--- a/app/django/apiV1/serializers/project.py
+++ b/app/django/apiV1/serializers/project.py
@@ -274,7 +274,10 @@ class SiteContractSerializer(serializers.ModelSerializer):
             except SiteContractFile.DoesNotExist:
                 raise serializers.ValidationError(f"File with ID {edit_file} does not exist.")
             except Exception as e:
-                raise serializers.ValidationError(f'Error while replacing file: {str(e)}')
+                import logging
+                logger = logging.getLogger(__name__)
+                logger.error(f'Error while replacing file: {str(e)}')
+                raise serializers.ValidationError('An error occurred while replacing the file.')
 
         del_file = self.initial_data.get('delFile', None)
         if del_file:


### PR DESCRIPTION
Fixes [https://github.com/nc2U/ibs/security/code-scanning/16](https://github.com/nc2U/ibs/security/code-scanning/16)

To fix the problem, we need to ensure that the exception message does not expose sensitive information to the user. Instead of returning the exception message directly, we should log the detailed error message on the server and return a generic error message to the user. This way, developers can still access the detailed error information for debugging purposes, but users will not see any sensitive information.

1. Modify the exception handling code to log the detailed error message on the server.
2. Return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
