### PR TITLE
Potential fix for code scanning alert no. 20: URL redirection from remote source

### DIFF
--- a/app/django/_config/urls.py
+++ b/app/django/_config/urls.py
@@ -18,6 +18,7 @@ from django.contrib import admin
 from django.contrib.auth import logout
 from django.shortcuts import redirect
 from django.urls import path, include
+from django.utils.http import url_has_allowed_host_and_scheme
 from rest_framework_simplejwt.views import (
     TokenObtainPairView,
     TokenVerifyView,
@@ -37,6 +38,8 @@ admin.site.site_title = 'IBS 사이트 관리'  # default: "Django site admin"
 
 def custom_logout(request):
     next_url = request.GET.get('next', 'accounts/login/')  # 기본값은 홈 페이지 ('/')
+    if not url_has_allowed_host_and_scheme(next_url, allowed_hosts=None):
+        next_url = 'accounts/login/'  # fallback to a safe URL
     logout(request)
     return redirect(next_url)
 


### PR DESCRIPTION
Potential fix for [https://github.com/nc2U/ibs/security/code-scanning/20](https://github.com/nc2U/ibs/security/code-scanning/20)

To fix the problem, we need to validate the `next_url` parameter to ensure it is a safe URL to redirect to. We can use Django's `url_has_allowed_host_and_scheme` function to check that the URL is safe. This function ensures that the URL is either relative or belongs to an allowed host.

- Import the `url_has_allowed_host_and_scheme` function from `django.utils.http`.
- Modify the `custom_logout` function to validate the `next_url` parameter before redirecting.
- If the `next_url` is not valid, redirect to a default safe URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
