### PR TITLE
Potential fix for code scanning alert no. 29: Information exposure through an exception

### DIFF
--- a/app/django/apiV1/views/contract.py
+++ b/app/django/apiV1/views/contract.py
@@ -1,4 +1,5 @@
 from django.core.cache import cache
+import logging
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Count, Sum, Q
 from django_filters import ChoiceFilter, ModelChoiceFilter, DateFilter, BooleanFilter
@@ -206,8 +207,9 @@ class ContractViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_404_NOT_FOUND
             )
         except Exception as e:
+            logging.exception("Error while getting payment plan")
             return Response(
-                {'error': f'Failed to get payment plan: {str(e)}'},
+                {'error': 'Failed to get payment plan due to an internal error.'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
 


### PR DESCRIPTION
Potential fix for [https://github.com/nc2U/ibs/security/code-scanning/29](https://github.com/nc2U/ibs/security/code-scanning/29)

To fix the problem, the server should only return a generic error message to clients when handling unexpected exceptions, while logging the actual exception server-side for further diagnosis. In this case, the code at line 210 currently returns the error message from the exception object, which could contain sensitive information. The best fix involves:
- Replacing the response on line 210 to send a generic error message such as `"Failed to get payment plan due to an internal error."` or `"An internal error occurred."`.
- Logging the exception internally (e.g., using Python’s `logging` module) to ensure developers can access the detailed traceback.
- If the `logging` module is not imported in this code block, import it at the top of the file.

All changes are to be made within app/django/apiV1/views/contract.py, specifically inside the `payment_plan` method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
