### PR TITLE
Potential fix for code scanning alert no. 28: Information exposure through an exception

### DIFF
--- a/app/django/apiV1/views/contract.py
+++ b/app/django/apiV1/views/contract.py
@@ -747,7 +747,8 @@ def contract_price_update_preview(request):
             'message': f'Project with ID {project_id} not found'
         }, status=status.HTTP_404_NOT_FOUND)
     except Exception as e:
+        logging.exception("Error occurred during contract price update preview")
         return Response({
             'success': False,
-            'message': f'조회 중 오류 발생: {str(e)}'
+            'message': '내부 서버 오류가 발생했습니다.'  # "An internal server error occurred." in Korean
         }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
Potential fix for [https://github.com/nc2U/ibs/security/code-scanning/28](https://github.com/nc2U/ibs/security/code-scanning/28)

To fix the issue, the error message returned to the client should not include details from the exception object, i.e., not use `str(e)` in the response body. Instead, a generic message such as "An internal error occurred" (or the Korean equivalent for localization consistency) should be returned to the user. Meanwhile, the actual exception with full details should be logged server-side using Python's standard logging framework, which is already imported as `logging`. To do this, update the `except Exception as e:` block to call `logging.exception(...)` to record the full stack trace, but replace the user-facing message with a safe, generic string. No new imports or dependencies are required.

You only need to update the `except Exception as e:` block near lines 749–753.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
