### PR TITLE
Potential fix for code scanning alert no. 27: Information exposure through an exception

### DIFF
--- a/app/django/apiV1/views/contract.py
+++ b/app/django/apiV1/views/contract.py
@@ -673,9 +673,10 @@ def bulk_update_contract_prices(request):
             })
 
     except Exception as e:
+        logging.exception("Error occurred during bulk contract price update")  # log stack trace
         return Response({
             'success': False,
-            'message': f'업데이트 중 오류 발생: {str(e)}'
+            'message': '업데이트 중 서버에 오류가 발생했습니다. 관리자에게 문의하세요.'
         }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/nc2U/ibs/security/code-scanning/27](https://github.com/nc2U/ibs/security/code-scanning/27)

To fix this problem, avoid returning the raw exception message (`str(e)`) to the client. Instead:
- Log the complete error (and stack trace) on the server side using the logging framework so that developers and system operators can review it.
- Respond to the user with a generic error message that does not reveal internal details.
Specifically, in the `except Exception as e:` block (lines 675-679), replace the error message so it says something like "업데이트 중 서버에 오류가 발생했습니다. 관리자에게 문의하세요" (generic server error in Korean), and ensure the error and stack trace are logged using Python's `logging` module.

You only need to modify this except block and add a logging call if one does not already exist in the shown context.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
