### PR TITLE
Potential fix for code scanning alert no. 26: Information exposure through an exception

### DIFF
--- a/app/django/apiV1/views/contract.py
+++ b/app/django/apiV1/views/contract.py
@@ -252,8 +252,9 @@ class ContractViewSet(viewsets.ModelViewSet):
                 )
 
         except (ValueError, OrderGroup.DoesNotExist, UnitType.DoesNotExist) as e:
+            logging.warning("Invalid parameter provided in multi_project_payment_summary", exc_info=True)
             return Response(
-                {'error': f'Invalid parameter provided: {str(e)}'},
+                {'error': 'Invalid parameter provided'},
                 status=status.HTTP_400_BAD_REQUEST
             )
 


### PR DESCRIPTION
Potential fix for [https://github.com/nc2U/ibs/security/code-scanning/26](https://github.com/nc2U/ibs/security/code-scanning/26)

The recommended fix is to replace the usage of `str(e)` in the API response with a generic, non-sensitive error message. The detailed error (with exception text and stack trace if desired) should be logged on the server using standard Python logging, but only a safe, generic message should be sent to the client.

Specifically, in `multi_project_payment_summary`, the following changes are required:
- Log the exception at an appropriate log level (e.g., `logger.warning` or `logger.error`) including the exception object, for server-side diagnostics.
- Return a generic message to the user, such as `{'error': 'Invalid parameter provided'}` without any exception details.

Because logging is already imported as `import logging`, we can use the logger directly (`logging.getLogger(__name__)`). If a logger object is needed in the method, define it at module level (or at function level if appropriate).

Only lines in `app/django/apiV1/views/contract.py` can be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
