### PR TITLE
Potential fix for code scanning alert no. 25: Information exposure through an exception

### DIFF
--- a/app/django/apiV1/views/contract.py
+++ b/app/django/apiV1/views/contract.py
@@ -137,8 +137,9 @@ class ContractViewSet(viewsets.ModelViewSet):
             unit_type = UnitType.objects.get(id=unit_type_id) if unit_type_id else None
 
         except (Project.DoesNotExist, OrderGroup.DoesNotExist, UnitType.DoesNotExist) as e:
+            logging.exception("Invalid ID provided in payment_summary endpoint.")
             return Response(
-                {'error': f'Invalid ID provided: {str(e)}'},
+                {'error': 'Invalid ID provided.'},
                 status=status.HTTP_400_BAD_REQUEST
             )
 


### PR DESCRIPTION
Potential fix for [https://github.com/nc2U/ibs/security/code-scanning/25](https://github.com/nc2U/ibs/security/code-scanning/25)

To fix the problem, avoid returning the actual exception message (i.e., `str(e)`) to the user and instead use a generic error message. Only log the exception details for server-side debugging. Specifically, in `payment_summary`, inside the `except`, change the response to:  
- Return a generic error (e.g., 'Invalid ID provided').  
- Optionally, log the exception using Python's logging system for developers to reference.

Edit the `except` block within the `payment_summary` method in `app/django/apiV1/views/contract.py` at lines 139–143, so that instead of exposing `str(e)` to the user, you only display a generic error and log the actual exception using the module-level logger (already imported).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
