### PR TITLE
Potential fix for code scanning alert no. 30: Information exposure through an exception

### DIFF
--- a/app/django/apiV1/views/payment.py
+++ b/app/django/apiV1/views/payment.py
@@ -6,12 +6,15 @@ from django_filters import DateFilter, CharFilter
 from django_filters.rest_framework import FilterSet
 from rest_framework import viewsets
 
+import logging
 from contract.models import ContractPrice
 from items.models import KeyUnit
 from .cash import ProjectCashBookViewSet
 from ..pagination import *
 from ..permission import *
 from ..serializers.payment import *
+
+logger = logging.getLogger(__name__)
 
 TODAY = datetime.today().strftime('%Y-%m-%d')
 
@@ -577,4 +580,5 @@ class SalesSummaryByGroupTypeViewSet(viewsets.ViewSet):
                 return Response(serializer.data)
 
         except Exception as e:
-            return Response({'error': str(e)}, status=500)
+            logger.exception(e)
+            return Response({'error': 'An internal server error occurred.'}, status=500)


### PR DESCRIPTION
Potential fix for [https://github.com/nc2U/ibs/security/code-scanning/30](https://github.com/nc2U/ibs/security/code-scanning/30)

To fix this problem, the code should ensure that detailed exception information is not returned to the client. Instead, a generic error message should be sent in the response, while the full stack trace and exception message should be logged on the server for later debugging by developers. This way, sensitive information remains protected from external users, but can still be reviewed internally for diagnostic purposes.

Specifically, in `app/django/apiV1/views/payment.py` in the `SalesSummaryByGroupTypeViewSet.list` method, replace `return Response({'error': str(e)}, status=500)` with a generic message, such as `return Response({'error': 'An internal server error occurred.'}, status=500)`. Additionally, use Django's logging framework to log the exception with its stack trace to the server logs before returning the response. If not already imported, import the `logging` module and get a logger instance using `logger = logging.getLogger(__name__)`. Then, inside the `except` block, use `logger.exception(e)` to log the error and stack trace.

All these changes can be made directly in the shown code region, with minimal disturbance to the rest of the logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
