### PR TITLE
Potential fix for code scanning alert no. 31: Information exposure through an exception

### DIFF
--- a/app/django/apiV1/views/payment.py
+++ b/app/django/apiV1/views/payment.py
@@ -755,13 +755,9 @@ class PaymentStatusByUnitTypeViewSet(viewsets.ViewSet):
                 return Response(serializer.data)
 
         except Exception as e:
-            import traceback
-            error_traceback = traceback.format_exc()
             logger.exception(f"PaymentStatusByUnitType API error: {str(e)}")
-            logger.error(f"Traceback: {error_traceback}")
             return Response({
-                'error': f'An internal server error occurred: {str(e)}',
-                'traceback': error_traceback
+                'error': 'An internal server error has occurred.'
             }, status=500)
 
     @staticmethod


### PR DESCRIPTION
Potential fix for [https://github.com/nc2U/ibs/security/code-scanning/31](https://github.com/nc2U/ibs/security/code-scanning/31)

The fix should ensure that stack trace details and exception messages are not returned in the API response to the user. Instead, we should log the stack trace and exception details to the server log for debugging, but only return a generic error message in the API response. This means changing the `except` block in the `PaymentStatusByUnitTypeViewSet.list` method:
- Remove `str(e)` and `error_traceback` from the API response.
- Ensure that the exception is still logged with the stack trace using `logger.exception()` (which already logs the stack trace).
- The user-facing response should only communicate that an internal server error has occurred.

No changes to imports are necessary, as `logging` and `traceback` are already available in the shown code, but the inline `import traceback` (line 758) should be removed (or left if you want, but unnecessary since it’s not reused elsewhere in the catch block).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
