### PR TITLE
Potential fix for code scanning alert no. 37: Information exposure through an exception

### DIFF
--- a/app/django/apiV1/views/notice.py
+++ b/app/django/apiV1/views/notice.py
@@ -3,8 +3,11 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
 
+import logging
 from ..permission import *
 from ..serializers.notice import *
+
+logger = logging.getLogger(__name__)
 
 from notice.models import SalesBillIssue
 from notice.utils import IwinvSMSService
@@ -219,12 +222,13 @@ class MessageViewSet(viewsets.ViewSet):
                 'message': str(e),
                 'success': 0,
                 'fail': len(validated_data.get('recipients', []))
+            logger.error("Internal server error in send_kakao", exc_info=True)
             }, status=status.HTTP_400_BAD_REQUEST)
 
         except Exception as e:
             return Response({
                 'code': -1,
-                'message': f'서버 오류: {str(e)}',
+                'message': '서버 내부 오류가 발생했습니다.',
                 'success': 0,
                 'fail': len(validated_data.get('recipients', []))
             }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
Potential fix for [https://github.com/nc2U/ibs/security/code-scanning/37](https://github.com/nc2U/ibs/security/code-scanning/37)

To prevent information disclosure, the exception handler should not include the full string representation of the exception in the API response. Instead, the error message shown to the user should be generic (e.g., "Internal server error occurred"), while the actual exception details should be logged server-side for administrative review. 

The best way to fix the problem in `app/django/apiV1/views/notice.py` (method `send_kakao`) is:
- Add a server-side logging call to capture the actual error (`logger.error(...)` with the exception details).
- Return a generic error message to the client, omitting the sensitive exception string.
- If not already present, import and configure the standard Python logging library at the top of this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
