### PR TITLE
Potential fix for code scanning alert no. 38: Information exposure through an exception

### DIFF
--- a/app/django/apiV1/views/notice.py
+++ b/app/django/apiV1/views/notice.py
@@ -3,12 +3,14 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
 
+import logging
 from ..permission import *
 from ..serializers.notice import *
 
 from notice.models import SalesBillIssue
 from notice.utils import IwinvSMSService
 
+logger = logging.getLogger(__name__)
 
 class BillIssueViewSet(viewsets.ModelViewSet):
     queryset = SalesBillIssue.objects.all()
@@ -215,6 +217,7 @@ class MessageViewSet(viewsets.ViewSet):
 
         except ValueError as e:
             # Handle case where validated_data might not be defined
+            logger.error("ValueError in send_kakao: %s", str(e), exc_info=True)
             fail_count = 0
             try:
                 fail_count = len(validated_data.get('recipients', []))
@@ -223,11 +226,12 @@ class MessageViewSet(viewsets.ViewSet):
 
             return Response({
                 'code': -1,
-                'message': str(e),
+                'message': '입력 값에 오류가 있습니다.',  # Generic error message for end user
                 'success': 0,
                 'fail': fail_count
             }, status=status.HTTP_400_BAD_REQUEST)
 
+            logger.error("Unhandled exception in send_kakao: %s", str(e), exc_info=True)
         except Exception as e:
             # Handle case where validated_data might not be defined
             fail_count = 0


### PR DESCRIPTION
Potential fix for [https://github.com/nc2U/ibs/security/code-scanning/38](https://github.com/nc2U/ibs/security/code-scanning/38)

To fix this problem, we should ensure that exception details, especially stack trace information and raw exception messages, are never sent directly to the client. Instead, the server should log the exception for diagnostics and return a generic error message in the API response.

**Concretely:**
- In the `except ValueError as e` branch, replace the line which injects `str(e)` into the `"message"` field with a safe, generic message (e.g., "입력 값에 오류가 있습니다." ["There is an error in the input values."]).
- Additionally, log the exception details (including stack trace) to the server logs for debugging purposes.
- If logging is not yet available in the snippet, you can safely import Python’s standard `logging` library at the top of the file and use `logger.error(...)` for logging errors.

**Which lines to change:**  
- Lines 224–226 (response in ValueError except block).
- Add logging: import at top, logger definition, and inside exception handlers.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
