### PR TITLE
Potential fix for code scanning alert no. 35: Information exposure through an exception

### DIFF
--- a/app/django/apiV1/views/notice.py
+++ b/app/django/apiV1/views/notice.py
@@ -2,6 +2,7 @@ from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
+import logging
 
 from ..permission import *
 from ..serializers.notice import *
@@ -159,9 +160,10 @@ class MessageViewSet(viewsets.ViewSet):
             }, status=status.HTTP_400_BAD_REQUEST)
 
         except Exception as e:
+            logging.exception("Unhandled exception occurred while sending MMS.")
             return Response({
                 'resultCode': -1,
-                'message': f'서버 오류: {str(e)}',
+                'message': '서버 내부 오류가 발생했습니다.',
                 'requestNo': None,
                 'msgType': 'MMS'
             }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
Potential fix for [https://github.com/nc2U/ibs/security/code-scanning/35](https://github.com/nc2U/ibs/security/code-scanning/35)

To address the issue, we should avoid returning the exception message to the client in the response for general exceptions (`except Exception as e`). Instead, a generic message should be provided to the client while the original error is logged on the server. This can be accomplished by:

- Modifying the except block on lines 161-167 to:
  - Log the full stack trace and exception information using Python's `logging` module or similar server-side logging.
  - Return a user-facing message such as `'서버 내부 오류가 발생했습니다.'` ("An internal server error occurred.") without revealing exception details.
- Importing the `logging` module at the top of the file, if not already present.
- Ensuring that the fix only changes what is returned to the user, without affecting how exceptions are logged.

All changes are located within `app/django/apiV1/views/notice.py`. The rest of the code remains unchanged, so the API’s error response structure stays compatible.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
