### PR TITLE
Potential fix for code scanning alert no. 34: Information exposure through an exception

### DIFF
--- a/app/django/apiV1/views/notice.py
+++ b/app/django/apiV1/views/notice.py
@@ -151,17 +151,22 @@ class MessageViewSet(viewsets.ViewSet):
             return Response(result, status=response_status)
 
         except ValueError as e:
+            # Optionally log the original error internally
+            # import logging is at the top if used; otherwise add as needed
+            # logging.error(f"ValueError in send_mms: {str(e)}")
             return Response({
                 'resultCode': -1,
-                'message': str(e),
+                'message': '입력 값 오류가 발생했습니다.',  # Generic message: "Input value error occurred."
                 'requestNo': None,
                 'msgType': 'MMS'
             }, status=status.HTTP_400_BAD_REQUEST)
 
         except Exception as e:
+            # Optionally log the original error internally
+            # logging.error(f"Unhandled exception in send_mms: {str(e)}")
             return Response({
                 'resultCode': -1,
-                'message': f'서버 오류: {str(e)}',
+                'message': '서버 내부 오류가 발생했습니다.',  # Generic message: "Internal server error occurred."
                 'requestNo': None,
                 'msgType': 'MMS'
             }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
Potential fix for [https://github.com/nc2U/ibs/security/code-scanning/34](https://github.com/nc2U/ibs/security/code-scanning/34)

To fix this issue, all direct responses containing unsanitized exception text—specifically, the details of `e`—should be replaced with a standardized, generic error message. Internal details should only be logged on the server for diagnostics, not exposed to the client. In file `app/django/apiV1/views/notice.py`, lines where `str(e)` is returned in a response (such as line 156) should be changed so the client only sees a non-detailed message like "Invalid input" or "A value error occurred." Server-side logging of the details (with something like Python's `logging` module) can be added if needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
