### PR TITLE
Potential fix for code scanning alert no. 39: Information exposure through an exception

### DIFF
--- a/app/django/apiV1/views/notice.py
+++ b/app/django/apiV1/views/notice.py
@@ -2,7 +2,7 @@ from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
-
+import logging
 from ..permission import *
 from ..serializers.notice import *
 
@@ -314,9 +314,10 @@ class MessageViewSet(viewsets.ViewSet):
             return Response(result, status=response_status)
 
         except ValueError as e:
+            logging.warning("ValueError in get_send_history: %s", str(e))
             return Response({
                 'resultCode': -1,
-                'message': str(e),
+                'message': '요청 값이 유효하지 않습니다.',  # "The request values are invalid."
                 'totalCount': 0,
                 'list': []
             }, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
Potential fix for [https://github.com/nc2U/ibs/security/code-scanning/39](https://github.com/nc2U/ibs/security/code-scanning/39)

To fix the information exposure, update the response in the `except ValueError as e` block to avoid including `str(e)` (the raw exception message) in the returned JSON. Instead, return a generic error message such as `'요청 값이 유효하지 않습니다.'` ("The request values are invalid."). To ensure that developers/operators can still debug issues, the underlying exception can be logged server-side (using Python's `logging` module), but user-facing error messages must remain generic.

**Steps:**
- Edit the except block on lines 316-322 in `app/django/apiV1/views/notice.py` so that the Response message is safe for end users.
- Add server-side logging for the exception in this block.
- If not already present, import the standard Python `logging` library.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
