### PR TITLE
Potential fix for code scanning alert no. 42: Information exposure through an exception

### DIFF
--- a/app/django/apiV1/views/docs.py
+++ b/app/django/apiV1/views/docs.py
@@ -388,9 +388,9 @@ class OfficialLetterViewSet(viewsets.ModelViewSet):
         letter = self.get_object()
         try:
             pdf_file = generate_official_letter_pdf(letter)
-        except Exception as e:
+        except Exception:
             return Response(
-                {'error': f'PDF 생성 실패: {e}'},
+                {'error': 'PDF 생성에 실패했습니다.'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
         letter.pdf_file = pdf_file


### PR DESCRIPTION
Potential fix for [https://github.com/nc2U/ibs/security/code-scanning/42](https://github.com/nc2U/ibs/security/code-scanning/42)

To fix this without changing functionality, keep the same control flow and status code but stop returning raw exception details to the client.

Best change in `app/django/apiV1/views/docs.py`:
- In `OfficialLetterViewSet.generate_pdf` `except Exception as e:` block:
  - Replace the response message containing `{e}` with a generic fixed string.
  - Optionally rename `e` to `_` to indicate it is intentionally unused.
- No new imports are required.

This preserves behavior (still returns 500 on failure) while preventing internal error detail exposure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
